### PR TITLE
updated IAM properties and dependencies for connecting MSK

### DIFF
--- a/foodie-server/pom.xml
+++ b/foodie-server/pom.xml
@@ -156,6 +156,13 @@
             <artifactId>openai-java</artifactId>
             <version>3.1.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>software.amazon.msk</groupId>
+            <artifactId>aws-msk-iam-auth</artifactId>
+            <version>2.3.4</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/foodie-server/src/main/resources/application.yml
+++ b/foodie-server/src/main/resources/application.yml
@@ -52,6 +52,11 @@ spring:
       auto-offset-reset: earliest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    properties:
+      security.protocol: SASL_SSL
+      sasl.mechanism: AWS_MSK_IAM
+      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
+      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler
 
 logging:
   level:


### PR DESCRIPTION
<dependency>
      <groupId>software.amazon.msk</groupId>
      <artifactId>aws-msk-iam-auth</artifactId>
      <version>2.3.4</version>
</dependency>

kafka:
    properties:
      security.protocol: SASL_SSL
      sasl.mechanism: AWS_MSK_IAM
      sasl.jaas.config: software.amazon.msk.auth.iam.IAMLoginModule required;
      sasl.client.callback.handler.class: software.amazon.msk.auth.iam.IAMClientCallbackHandler